### PR TITLE
[ContractAction] get list and create API

### DIFF
--- a/hack/files/database.sql
+++ b/hack/files/database.sql
@@ -196,6 +196,27 @@ COMMENT ON COLUMN comunion.categories.source IS 'startup';
 
 
 --
+-- Name: contract_actions; Type: TABLE; Schema: comunion; Owner: -
+--
+
+CREATE TABLE comunion.contract_actions (
+    id character varying(255) NOT NULL,
+    uid bigint NOT NULL,
+    type integer NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    CONSTRAINT contract_actions_pkey PRIMARY KEY (id, uid, type)
+);
+
+
+--
+-- Name: COLUMN contract_actions.type; Type: COMMENT; Schema: comunion; Owner: -
+--
+
+COMMENT ON COLUMN comunion.contract_actions.type IS 'DISCO: 1';
+
+
+--
 -- Name: disco_investors; Type: TABLE; Schema: comunion; Owner: -
 --
 
@@ -242,12 +263,15 @@ CREATE TABLE comunion.exchange_transactions (
     id bigint DEFAULT comunion.id_generator() NOT NULL,
     tx_id text NOT NULL,
     exchange_id bigint NOT NULL,
-    account text NOT NULL,
+    sender text DEFAULT ''::text NOT NULL,
+    receiver text DEFAULT ''::text NOT NULL,
     type integer NOT NULL,
     name text DEFAULT ''::text NOT NULL,
     total_value double precision DEFAULT 0 NOT NULL,
     token_amount1 double precision DEFAULT 0 NOT NULL,
     token_amount2 double precision DEFAULT 0 NOT NULL,
+    amount0 text DEFAULT ''::text NOT NULL,
+    amount1 text DEFAULT ''::text NOT NULL,
     fee double precision DEFAULT 0 NOT NULL,
     price_per_token1 double precision DEFAULT 0 NOT NULL,
     price_per_token2 double precision DEFAULT 0 NOT NULL,
@@ -285,17 +309,21 @@ CREATE TABLE comunion.exchanges (
     token_name1 text NOT NULL,
     token_symbol1 text NOT NULL,
     token_address1 text,
+    token_divider1 bigint DEFAULT 1 NOT NULL,
     token_name2 text NOT NULL,
     token_symbol2 text NOT NULL,
     token_address2 text,
-    newest_day text,
+    token_divider2 bigint DEFAULT 1 NOT NULL,
+    newest_day text DEFAULT ''::text NOT NULL,
     newest_pooled_tokens1 double precision DEFAULT 0 NOT NULL,
     newest_pooled_tokens2 double precision DEFAULT 0 NOT NULL,
-    last_day text,
+    last_day text DEFAULT ''::text NOT NULL,
     last_pooled_tokens1 double precision DEFAULT 0 NOT NULL,
     last_pooled_tokens2 double precision DEFAULT 0 NOT NULL,
     price double precision DEFAULT 0 NOT NULL,
     fees double precision DEFAULT 0 NOT NULL,
+    reserve0 text DEFAULT ''::text NOT NULL,
+    reserve1 text DEFAULT ''::text NOT NULL,
     status integer DEFAULT 0 NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -339,6 +367,96 @@ CREATE TABLE comunion.hunters (
 
 
 --
+-- Name: proposal_terms; Type: TABLE; Schema: comunion; Owner: -
+--
+
+CREATE TABLE comunion.proposal_terms (
+    id bigint DEFAULT comunion.id_generator() NOT NULL,
+    proposal_id bigint NOT NULL,
+    amount double precision NOT NULL,
+    content text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: proposal_votes; Type: TABLE; Schema: comunion; Owner: -
+--
+
+CREATE TABLE comunion.proposal_votes (
+    id bigint DEFAULT comunion.id_generator() NOT NULL,
+    tx_id text NOT NULL,
+    proposal_id bigint NOT NULL,
+    amount double precision NOT NULL,
+    is_approved boolean NOT NULL,
+    wallet_addr text NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: proposals; Type: TABLE; Schema: comunion; Owner: -
+--
+
+CREATE TABLE comunion.proposals (
+    id bigint DEFAULT comunion.id_generator() NOT NULL,
+    tx_id text NOT NULL,
+    startup_id bigint NOT NULL,
+    wallet_addr text NOT NULL,
+    contract_addr text NOT NULL,
+    status integer DEFAULT 0 NOT NULL,
+    title text NOT NULL,
+    type integer NOT NULL,
+    user_id bigint NOT NULL,
+    contact text NOT NULL,
+    description text NOT NULL,
+    voter_type integer NOT NULL,
+    supporters integer NOT NULL,
+    minimum_approval_percentage integer NOT NULL,
+    duration integer NOT NULL,
+    has_payment boolean NOT NULL,
+    payment_addr text,
+    payment_type smallint,
+    payment_months integer,
+    payment_date text,
+    payment_amount double precision,
+    total_payment_amount double precision,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: COLUMN proposals.status; Type: COMMENT; Schema: comunion; Owner: -
+--
+
+COMMENT ON COLUMN comunion.proposals.status IS '0：待确认，1：未开始，2：进行中，3：已结束，4：未成案，5：提案被拒绝，6：提案被通过';
+
+
+--
+-- Name: COLUMN proposals.type; Type: COMMENT; Schema: comunion; Owner: -
+--
+
+COMMENT ON COLUMN comunion.proposals.type IS '1：Finance，2：Governance，3：Strategy，4：Product，5：Media，6：Community，7：Node';
+
+
+--
+-- Name: COLUMN proposals.voter_type; Type: COMMENT; Schema: comunion; Owner: -
+--
+
+COMMENT ON COLUMN comunion.proposals.voter_type IS '1：FounderAssign，2：POS，3：All';
+
+
+--
+-- Name: COLUMN proposals.payment_type; Type: COMMENT; Schema: comunion; Owner: -
+--
+
+COMMENT ON COLUMN comunion.proposals.payment_type IS '1：一次性支付，2：按月支付';
+
+
+--
 -- Name: startup_revisions; Type: TABLE; Schema: comunion; Owner: -
 --
 
@@ -366,26 +484,19 @@ CREATE TABLE comunion.startup_setting_revisions (
     token_symbol text NOT NULL,
     token_addr text,
     wallet_addrs jsonb DEFAULT '[]'::jsonb NOT NULL,
-    voter_type integer NOT NULL,
     voter_token_limit bigint,
-    assigned_proposers text[],
-    assigned_voters text[],
-    proposer_type integer NOT NULL,
-    proposer_token_limit bigint,
-    proposal_supporters bigint NOT NULL,
-    proposal_min_approval_percent bigint NOT NULL,
-    proposal_min_duration bigint NOT NULL,
-    proposal_max_duration bigint NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    proposer_type integer DEFAULT 1 NOT NULL,
+    proposer_token_limit bigint NOT NULL,
+    proposal_supporters bigint DEFAULT 0 NOT NULL,
+    proposal_min_approval_percent bigint DEFAULT 0 NOT NULL,
+    proposal_min_duration bigint DEFAULT 0 NOT NULL,
+    proposal_max_duration bigint DEFAULT 0 NOT NULL,
+    assigned_voters text[],
+    assigned_proposers text[],
+    voter_type integer DEFAULT 1 NOT NULL
 );
-
-
---
--- Name: COLUMN startup_setting_revisions.voter_type; Type: COMMENT; Schema: comunion; Owner: -
---
-
-COMMENT ON COLUMN comunion.startup_setting_revisions.voter_type IS 'FounderAssign 指定人投票 持有一定数量token的人才可以投票;POS;ALL 所有人投票';
 
 
 --
@@ -488,14 +599,14 @@ COMMENT ON COLUMN comunion.transactions.state IS '1 等待确认，2 已确认�
 
 CREATE TABLE comunion.users (
     id bigint DEFAULT comunion.id_generator() NOT NULL,
-    avatar text NOT NULL,
     public_key text NOT NULL,
     nonce text NOT NULL,
     public_secret text NOT NULL,
     private_secret text NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
-    is_hunter boolean DEFAULT false NOT NULL
+    is_hunter boolean DEFAULT false NOT NULL,
+    avatar text NOT NULL
 );
 
 
@@ -568,6 +679,30 @@ ALTER TABLE ONLY comunion.exchanges
 
 ALTER TABLE ONLY comunion.hunters
     ADD CONSTRAINT hunters_id_pk PRIMARY KEY (id);
+
+
+--
+-- Name: proposal_terms proposal_terms_id_pk; Type: CONSTRAINT; Schema: comunion; Owner: -
+--
+
+ALTER TABLE ONLY comunion.proposal_terms
+    ADD CONSTRAINT proposal_terms_id_pk PRIMARY KEY (id);
+
+
+--
+-- Name: proposal_votes proposal_votes_id_pk; Type: CONSTRAINT; Schema: comunion; Owner: -
+--
+
+ALTER TABLE ONLY comunion.proposal_votes
+    ADD CONSTRAINT proposal_votes_id_pk PRIMARY KEY (id);
+
+
+--
+-- Name: proposals proposals_id_pk; Type: CONSTRAINT; Schema: comunion; Owner: -
+--
+
+ALTER TABLE ONLY comunion.proposals
+    ADD CONSTRAINT proposals_id_pk PRIMARY KEY (id);
 
 
 --

--- a/src/cores/cmd/cores/app/app.go
+++ b/src/cores/cmd/cores/app/app.go
@@ -7,6 +7,7 @@ import (
 	"cos-backend-com/src/cores"
 	"cos-backend-com/src/cores/routers/bounties"
 	"cos-backend-com/src/cores/routers/categories"
+	"cos-backend-com/src/cores/routers/contract"
 	"cos-backend-com/src/cores/routers/discos"
 	"cos-backend-com/src/cores/routers/exchanges"
 	"cos-backend-com/src/cores/routers/files"
@@ -137,7 +138,6 @@ func (p *appConfig) ConfigRoutes() {
 				s.Router("/isBinding",
 					s.Get(startups.StartUpsHandler{}).Action("IsTokenAddrBinding"),
 				),
-
 			),
 			//restore startup settings
 			s.Router("/:id/settings:restore",
@@ -273,7 +273,7 @@ func (p *appConfig) ConfigRoutes() {
 		),
 		s.Router("/proposal/:id",
 			// s.Filter(filters.LoginRequiredInner),
-			s.Post(proposals.ProposalEventsHandler{}).Action("UpdateProposalStatus"),
+			s.Put(proposals.ProposalEventsHandler{}).Action("UpdateProposalStatus"),
 			s.Router("/vote", s.Post(proposals.ProposalEventsHandler{}).Action("VoteProposal")),
 		),
 
@@ -305,6 +305,17 @@ func (p *appConfig) ConfigRoutes() {
 		),
 		s.Router("/discos:statDiscoTotal",
 			s.Post(discos.DiscosHandler{}).Action("StatDiscoTotal"),
+		),
+
+		s.Router("/contract",
+			s.Router("/actions",
+				s.Router("/:type",
+					s.Get(contract.ContractActionsHandler{}).Filter(filters.LoginRequiredInner).Action("List"),
+					s.Post(contract.ContractActionsHandler{}).Filter(filters.LoginRequiredInner).Action("Create"),
+					s.Router("/:id",
+						s.Get(contract.ContractActionsHandler{}).Filter(filters.LoginRequiredInner).Action("Get")),
+				),
+			),
 		),
 	)
 }

--- a/src/cores/routers/contract/contract_actions.go
+++ b/src/cores/routers/contract/contract_actions.go
@@ -1,0 +1,76 @@
+package contract
+
+import (
+	"cos-backend-com/src/common/flake"
+	"cos-backend-com/src/common/validate"
+	"cos-backend-com/src/cores/routers"
+	"cos-backend-com/src/libs/apierror"
+	"cos-backend-com/src/libs/models/contractmodels"
+	"cos-backend-com/src/libs/sdk/cores"
+	"net/http"
+
+	"github.com/wujiu2020/strip/utils/apires"
+)
+
+type ContractActionsHandler struct {
+	routers.Base
+}
+
+func (h *ContractActionsHandler) Create(actionType cores.ContractActionType) (res interface{}) {
+	var input cores.CreateContractActionInput
+	if err := h.Params.BindJsonBody(&input); err != nil {
+		h.Log.Warn(err)
+		res = apierror.HandleError(err)
+		return
+	}
+
+	if err := validate.Default.Struct(input); err != nil {
+		h.Log.Warn(err)
+		res = apierror.HandleError(err)
+		return
+	}
+
+	var uid flake.ID
+	h.Ctx.Find(&uid, "uid")
+
+	if err := contractmodels.ContractActions.Create(h.Ctx, uid, actionType, &input); err != nil {
+		h.Log.Warn(err)
+		res = apierror.HandleError(err)
+		return
+	}
+
+	res = apires.With(http.StatusOK)
+	return
+}
+
+func (h *ContractActionsHandler) Get(actionType cores.ContractActionType, id string) (res interface{}) {
+	var output cores.ContractActionResult
+
+	var uid flake.ID
+	h.Ctx.Find(&uid, "uid")
+
+	if err := contractmodels.ContractActions.Get(h.Ctx, id, uid, actionType, &output); err != nil {
+		h.Log.Warn(err)
+		res = apierror.HandleError(err)
+		return
+	}
+
+	res = apires.With(&output, http.StatusOK)
+	return
+}
+
+func (h *ContractActionsHandler) List(actionType cores.ContractActionType) (res interface{}) {
+	var output []cores.ContractActionResult
+
+	var uid flake.ID
+	h.Ctx.Find(&uid, "uid")
+
+	if err := contractmodels.ContractActions.List(h.Ctx, uid, actionType, &output); err != nil {
+		h.Log.Warn(err)
+		res = apierror.HandleError(err)
+		return
+	}
+
+	res = apires.With(&output, http.StatusOK)
+	return
+}

--- a/src/libs/models/contractmodels/contract_actions.go
+++ b/src/libs/models/contractmodels/contract_actions.go
@@ -1,0 +1,76 @@
+package contractmodels
+
+import (
+	"context"
+	"cos-backend-com/src/common/dbconn"
+	"cos-backend-com/src/common/flake"
+	"cos-backend-com/src/common/util"
+	"cos-backend-com/src/libs/models"
+	"cos-backend-com/src/libs/sdk/cores"
+
+	"github.com/jmoiron/sqlx"
+)
+
+var ContractActions = &contractActions{
+	Connector: models.DefaultConnector,
+}
+
+type contractActions struct {
+	dbconn.Connector
+}
+
+func (c *contractActions) Create(ctx context.Context, uid flake.ID, actionType cores.ContractActionType, input *cores.CreateContractActionInput) (err error) {
+	stmt := `
+		INSERT INTO contract_actions (id, uid, type) VALUES (${id}, ${uid}, ${type});
+	`
+	query, args := util.PgMapQueryV2(stmt, map[string]interface{}{
+		"{id}":   input.Id,
+		"{uid}":  uid,
+		"{type}": actionType,
+	})
+
+	return c.Invoke(ctx, func(db *sqlx.DB) (er error) {
+		_, err = db.ExecContext(ctx, query, args...)
+		return err
+	})
+}
+
+func (c *contractActions) List(ctx context.Context, uid flake.ID, actionType cores.ContractActionType, output interface{}) (err error) {
+	stmt := `
+		WITH res AS (
+			SELECT *
+			FROM contract_actions
+			WHERE uid = ${uid} AND type = ${actionType}
+			ORDER BY created_at DESC
+		)
+		SELECT COALESCE(json_agg(r.*), '[]'::json) FROM res r;
+	`
+	query, args := util.PgMapQueryV2(stmt, map[string]interface{}{
+		"{uid}":        uid,
+		"{actionType}": actionType,
+	})
+
+	return c.Invoke(ctx, func(db dbconn.Q) error {
+		return db.GetContext(ctx, &util.PgJsonScanWrap{output}, query, args...)
+	})
+}
+
+func (c *contractActions) Get(ctx context.Context, id string, uid flake.ID, actionType, output interface{}) (err error) {
+	stmt := `
+		WITH res AS (
+			SELECT *
+			FROM contract_actions
+			WHERE uid = ${uid} AND type = ${actionType} AND id = ${id}
+		)
+		SELECT row_to_json(r) FROM res r;
+	`
+	query, args := util.PgMapQueryV2(stmt, map[string]interface{}{
+		"{id}":         id,
+		"{uid}":        uid,
+		"{actionType}": actionType,
+	})
+
+	return c.Invoke(ctx, func(db dbconn.Q) (er error) {
+		return db.GetContext(ctx, &util.PgJsonScanWrap{output}, query, args...)
+	})
+}

--- a/src/libs/sdk/cores/contract_actions.go
+++ b/src/libs/sdk/cores/contract_actions.go
@@ -1,0 +1,33 @@
+package cores
+
+import (
+	"cos-backend-com/src/common/flake"
+	"time"
+)
+
+type ContractActionType int
+
+const (
+	ContractActionTypeDefault ContractActionType = iota
+	ContractActionTypeDefaultDisco
+)
+
+type ConctractActionsModel struct {
+	Id        string             `json:"id" db:"id"`
+	Uid       flake.ID           `json:"uid" db:"uid"`
+	Type      ContractActionType `json:"type" db:"type"`
+	CreatedAt time.Time          `json:"createdAt" db:"created_at"`
+	UpdatedAt time.Time          `json:"updatedAt" db:"updated_at"`
+}
+
+type CreateContractActionInput struct {
+	Id string `json:"id" validate:"required"`
+}
+
+type ContractActionResult struct {
+	Id        string             `json:"id" db:"id"`
+	Uid       flake.ID           `json:"uid" db:"uid"`
+	Type      ContractActionType `json:"type" db:"type"`
+	CreatedAt time.Time          `json:"createdAt" db:"created_at"`
+	UpdatedAt time.Time          `json:"updatedAt" db:"updated_at"`
+}


### PR DESCRIPTION
增加三个关于合约动作的 API：

- 获取合约动作 `GET /cores/contract/actions/{contractActionType}/{id}`
- 获取合约动作列表 `GET /cores/contract/actions/{contractActionType}`
- 创建合约动作 `POST /cores/contract/actions/{contractActionType}`
- 按照 dev 最新的数据库结构更新 `database.sql`